### PR TITLE
Rewrite, more or less

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2013 Leif Bladt, Johannes Faigle
+Copyright (c) 2013 Leif Bladt, Johannes Faigle, Mark Wise
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.markdown
+++ b/README.markdown
@@ -5,17 +5,28 @@ Some helpers for focused RSpec testruns. See this [Railscast](http://railscasts.
 
 ## Usage
 
-There are currently two commands:
+Includes the following commands:
+
+* ToggleFocusTag
 * AddFocusTag
+* RemoveFocusTags
 * RemoveAllFocusTags
+* ToggleDescribeFocusTag
+* ToggleContextFocusTag
+* ToggleItFocusTag
 
 ## Installation
 
-Use [pathogen.vim](https://github.com/tpope/vim-pathogen)
+Use [pathogen.vim](https://github.com/tpope/vim-pathogen) or [Vundle.vim](https://github.com/gmarik/Vundle.vim)
 
 ### Key bindings
 To make it more convenient, add some key bindings to your `.vimrc`:
 
     " vim-rspec-focus
-    :nnoremap <leader>t :AddFocusTag<CR>
-    :nnoremap <leader>r :RemoveAllFocusTags<CR>
+    :nnoremap <leader>ff :ToggleFocusTag<CR>
+    :nnoremap <leader>fa :AddFocusTag<CR>
+    :nnoremap <leader>fr :RemoveFocusTag<CR>
+    :nnoremap <leader>fd :ToggleDescribeFocusTag<CR>
+    :nnoremap <leader>fc :ToggleContextFocusTag<CR>
+    :nnoremap <leader>fi :ToggleItFocusTag<CR>
+    :nnoremap <leader>rf :RemoveAllFocusTags<CR>

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -51,7 +51,7 @@ fun! s:AddFocusTag(pattern)
       let patternToReplace = singleLineAssertionPattern
       let replacement = 'it "", { focus: true } { '
     else
-      let patternToReplace = ' do$'
+      let patternToReplace = ' do\s*$'
       let replacement = ", focus: true do"
     endif
     let repl = substitute(line, patternToReplace, replacement, "")

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -15,49 +15,63 @@ function! s:Preserve(command)
   let @/ = histget("search", -1)
 endfunction
 
-function! s:AddFocusTag()
-  call s:Preserve("normal! ? do\<cr>C, :focus do\<esc>")
-endfunction
+fun! s:LineHasFocusTag(line)
+  return match(a:line, "focus: true") >= 0
+endfun
+
+fun! s:ToggleFocusTag(...)
+  if a:0 > 0
+    let pattern = a:1
+  else
+    let pattern = s:focusablesPattern
+  endif
+  let match = search(pattern, 'bWn')
+  :let line = getline(match)
+
+  if s:LineHasFocusTag(line)
+    call s:RemoveFocusTag(pattern)
+  else
+    call s:AddFocusTag(pattern)
+  endif
+endfun
+
+fun! s:AddFocusTag(pattern)
+  let match = search(a:pattern, 'bWn')
+  :let line = getline(match)
+  if s:LineHasFocusTag(line)
+  else
+    if match(line, "it { ") >= 0
+      :let repl = substitute(line, 'it { ', 'it "", { focus: true } { ', "")
+    else
+      :let repl = substitute(line, ' do$', ", focus: true do", "")
+    endif
+    :call setline(match, repl)
+  endif
+endfun
+
+fun! s:RemoveFocusTag(pattern)
+  let match = search(a:pattern, 'bWn')
+  :let line = getline(match)
+  if s:LineHasFocusTag(line)
+    if match(line, '"", { focus: true } ') >= 0
+      :let repl = substitute(line, '"", { focus: true } ', "", "g")
+    else
+      :let repl = substitute(line, ', focus: true', "", "g")
+    endif
+    :call setline(match, repl)
+  endif
+endfun
 
 function! s:RemoveAllFocusTags()
-  call s:Preserve("%s/, focus: true")
+  call s:Preserve("%s/, focus: true//e")
 endfunction
 
-fun! s:RSpecToggleFocus()
-  let match = search(s:focusablesPattern, 'bWn')
-  :let line = getline(match)
-
-  if match(line, "focus") >= 0
-    call s:RSpecRemoveFocus()
-  else
-    call s:RSpecAddFocus()
-  endif
-endfun
-
-fun! s:RSpecAddFocus()
-  let match = search(s:focusablesPattern, 'bWn')
-  :let line = getline(match)
-  if match(line, "focus: true") >= 0
-  else
-    :let repl = substitute(line, ' do$', ", focus: true do", "")
-    :call setline(match, repl)
-  endif
-endfun
-
-fun! s:RSpecRemoveFocus()
-  let match = search(s:focusablesPattern, 'bWn')
-  :let line = getline(match)
-  if match(line, "focus: true") >= 0
-    :let repl = substitute(line, ', focus: true', "", "g")
-    :call setline(match, repl)
-  endif
-endfun
-
 " Commands
-command! -nargs=0 AddFocusTag call s:AddFocusTag()
+command! -nargs=0 ToggleFocusTag call s:ToggleFocusTag()
+command! -nargs=0 AddFocusTag call s:AddFocusTag(s:focusablesPattern)
+command! -nargs=0 RemoveFocusTag call s:RemoveFocusTag(s:focusablesPattern)
 command! -nargs=0 RemoveAllFocusTags call s:RemoveAllFocusTags()
-command! -nargs=0 RSpecClearFoci :%s/, focus: true//g
 
-command! -nargs=0 RSpecToggleFocus call s:RSpecToggleFocus()
-command! -nargs=0 RSpecAddFocus call s:RSpecAddFocus()
-command! -nargs=0 RSpecRemoveFocus call s:RSpecRemoveFocus()
+command! -nargs=0 ToggleDescribeFocusTag call s:ToggleFocusTag("describe")
+command! -nargs=0 ToggleContextFocusTag call s:ToggleFocusTag("context")
+command! -nargs=0 ToggleItFocusTag call s:ToggleFocusTag("it")

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -30,7 +30,7 @@ fun! s:ToggleFocusTag(...)
     let pattern = s:focusablesPattern
   endif
   let match = search(pattern, 'bcWn')
-  :let line = getline(match)
+  let line = getline(match)
 
   if s:LineHasFocusTag(line)
     call s:RemoveFocusTag(pattern)
@@ -42,36 +42,36 @@ endfun
 
 fun! s:AddFocusTag(pattern)
   let match = search(a:pattern, 'bcWn')
-  :let line = getline(match)
+  let line = getline(match)
   if s:LineHasFocusTag(line)
   else
     " is this is a single-line assertion w/ no description?
     let singleLineAssertionPattern = 'it { '
     if match(line, singleLineAssertionPattern) >= 0
-      :let patternToReplace = singleLineAssertionPattern
-      :let replacement = 'it "", { focus: true } { '
+      let patternToReplace = singleLineAssertionPattern
+      let replacement = 'it "", { focus: true } { '
     else
-      :let patternToReplace = ' do$'
-      :let replacement = ", focus: true do"
+      let patternToReplace = ' do$'
+      let replacement = ", focus: true do"
     endif
-    :let repl = substitute(line, patternToReplace, replacement, "")
-    :call setline(match, repl)
+    let repl = substitute(line, patternToReplace, replacement, "")
+    call setline(match, repl)
   endif
 endfun
 
 fun! s:RemoveFocusTag(pattern)
   let match = search(a:pattern, 'bcWn')
-  :let line = getline(match)
+  let line = getline(match)
   if s:LineHasFocusTag(line)
     " is this is a focused single-line assertion w/ no description?
     let focusedSingleLineAssertionPattern = '"", { focus: true } '
     if match(line, focusedSingleLineAssertionPattern) >= 0
-      :let patternToReplace = focusedSingleLineAssertionPattern
+      let patternToReplace = focusedSingleLineAssertionPattern
     else
-      :let patternToReplace = ', focus: true'
+      let patternToReplace = ', focus: true'
     endif
-    :let repl = substitute(line, patternToReplace, "", "g")
-    :call setline(match, repl)
+    let repl = substitute(line, patternToReplace, "", "g")
+    call setline(match, repl)
   endif
 endfun
 

--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -1,3 +1,5 @@
+let s:focusablesPattern = 'describe\|context\|it\|scenario\|feature\|specify'
+
 function! s:Preserve(command)
   " Save cursor position
   let l = line(".")
@@ -18,9 +20,44 @@ function! s:AddFocusTag()
 endfunction
 
 function! s:RemoveAllFocusTags()
-  call s:Preserve("%s/, :focus//e")
+  call s:Preserve("%s/, focus: true")
 endfunction
+
+fun! s:RSpecToggleFocus()
+  let match = search(s:focusablesPattern, 'bWn')
+  :let line = getline(match)
+
+  if match(line, "focus") >= 0
+    call s:RSpecRemoveFocus()
+  else
+    call s:RSpecAddFocus()
+  endif
+endfun
+
+fun! s:RSpecAddFocus()
+  let match = search(s:focusablesPattern, 'bWn')
+  :let line = getline(match)
+  if match(line, "focus: true") >= 0
+  else
+    :let repl = substitute(line, ' do$', ", focus: true do", "")
+    :call setline(match, repl)
+  endif
+endfun
+
+fun! s:RSpecRemoveFocus()
+  let match = search(s:focusablesPattern, 'bWn')
+  :let line = getline(match)
+  if match(line, "focus: true") >= 0
+    :let repl = substitute(line, ', focus: true', "", "g")
+    :call setline(match, repl)
+  endif
+endfun
 
 " Commands
 command! -nargs=0 AddFocusTag call s:AddFocusTag()
 command! -nargs=0 RemoveAllFocusTags call s:RemoveAllFocusTags()
+command! -nargs=0 RSpecClearFoci :%s/, focus: true//g
+
+command! -nargs=0 RSpecToggleFocus call s:RSpecToggleFocus()
+command! -nargs=0 RSpecAddFocus call s:RSpecAddFocus()
+command! -nargs=0 RSpecRemoveFocus call s:RSpecRemoveFocus()


### PR DESCRIPTION
Hello,

I came across vim-rspec-focus while looking for a plugin that would do the add/remove/toggle focus stuff I'd had in my vimrc for a while. I forked your plugin and ended up rewriting most of it. I kept the original API for AddFocusTag and RemoveAllFocusTags, but changed the implementation and added a few other niceties like describe-, context-, and it-aware functions and the ToggleFocusTag() function.

Please let me know if you would considering merging in this pull request, or if you would prefer that I just split off the repo entirely.

Cheers,

Mark
