### PR TITLE
Respect before, after, etc. blocks in lookup

### DIFF
--- a/ftplugin/ruby.vim
+++ b/ftplugin/ruby.vim
@@ -14,7 +14,7 @@ function! s:Preserve(command)
 endfunction
 
 function! s:AddFocusTag()
-  call s:Preserve("normal! ? do\<cr>C, :focus do\<esc>")
+  call s:Preserve("normal! ?\\(^\\s*\\(expect\\|before\\|after\\|let\\).*\\)\\@<! do\<cr>C, :focus do\<esc>")
 endfunction
 
 function! s:RemoveAllFocusTags()


### PR DESCRIPTION
Currently `:AddFocusTag` in a context with a `before do` block will wrongly
insert `before do, :focus`. This PR adds a corresponding negative assertion to
the regex in the lookup so that such patterns are correctly ignored.

[EDIT] I'm closing this PR in favour of the existing PR addressing the same issue https://github.com/unifieddialog/vim-rspec-focus/pull/13
